### PR TITLE
Update meta tags in head include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,8 +22,9 @@
     <link rel="shortcut icon" id="favicon" type="image/x-icon" href="/images/favicon-dark.ico">
 
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <meta name="description" content="" />
-    <meta name="keywords" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
+    <meta name="keywords" content="{{ page.keywords | default: site.keywords }}" />
     <!--[if lte IE 8]><script src="js/html5shiv.js"></script><![endif]-->
     <script src="{{ site.baseurl }}/js/jquery.min.js"></script>
     <script src="{{ site.baseurl }}/js/skel.min.js"></script>


### PR DESCRIPTION
## Summary
- add a responsive viewport meta tag to the shared head include
- populate the meta description dynamically from the page or site description
- restore the keywords meta tag with a fallback to page or site keywords

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8d3b0e1488331ad3a67b424045e08