### PR TITLE
Track GA adoption clicks

### DIFF
--- a/adoptions.html
+++ b/adoptions.html
@@ -36,7 +36,35 @@ title: Adoptions | Bay Area Cats
         </div> -->
 
         <br/>
-        <a class="donate-button" href="https://new.shelterluv.com/matchme/adopt/BAH/Cat" style="text-decoration: none;" target="_top">Adoption application</a>
+        <a class="donate-button" id="adoption-application-button" href="https://new.shelterluv.com/matchme/adopt/BAH/Cat" style="text-decoration: none;" target="_top">Adoption application</a>
+        <script>
+          (function () {
+            function registerAdoptionTracking() {
+              var adoptButton = document.getElementById('adoption-application-button');
+              if (!adoptButton) {
+                return;
+              }
+
+              adoptButton.addEventListener('click', function () {
+                if (typeof window.gtag !== 'function') {
+                  return;
+                }
+
+                window.gtag('event', 'adopt_click', {
+                  event_category: 'adoptions',
+                  event_label: 'adoptions_page',
+                  transport_type: 'beacon'
+                });
+              });
+            }
+
+            if (document.readyState === 'loading') {
+              document.addEventListener('DOMContentLoaded', registerAdoptionTracking);
+            } else {
+              registerAdoptionTracking();
+            }
+          })();
+        </script>
 
 
     </section>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,35 @@ layout: landing-page
     <div id="donations">
       <form action="https://www.paypal.com/donate" method="post" target="_top">
       <input type="hidden" name="hosted_button_id" value="3CU9XS5BLTLWE" />
-      <button class="donate-button" type="submit">Donate to help save lives</button>
+      <button class="donate-button" id="donate-button-home" type="submit">Donate to help save lives</button>
+      <script>
+        (function () {
+          function registerDonateTracking() {
+            var donateButton = document.getElementById('donate-button-home');
+            if (!donateButton) {
+              return;
+            }
+
+            donateButton.addEventListener('click', function () {
+              if (typeof window.gtag !== 'function') {
+                return;
+              }
+
+              window.gtag('event', 'donate_click', {
+                event_category: 'donations',
+                event_label: 'homepage',
+                transport_type: 'beacon'
+              });
+            });
+          }
+
+          if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', registerDonateTracking);
+          } else {
+            registerDonateTracking();
+          }
+        })();
+      </script>
       <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
 </form>
     <p>To decrease the number of unfixed cats in the community. Bay Area Cats is a 501(c)(3) non-profit organization. Our organization provides resources and enables the community to do trap-neuter-return (TNR). We spend time training, educating, rescuing kittens, and assisting with TNR efforts. We help connect people to spay/neuter resources and support those with financial need. Our community cats and kittens could use your help! You can also donate via <a target="_blank" href="https://www.paypal.com/donate/?hosted_button_id=85C7UMCXTS2GC">PayPal</a> or <a href="https://venmo.com/code?user_id=3668070472091276232">Venmo</a>, and through our <a href="https://www.chewy.com/g/bay-area-cats_b103747788?utm_medium=email&utm_source=transactional&utm_campaign=SHELTER_BUSINESS_PAGE_APPROVED#wish-list">Chewy</a> or <a href="https://a.co/4CxxGb9">Amazon Wishlist</a>.<p>


### PR DESCRIPTION
## Summary
- add a DOM-ready handler for the adoption application button
- send a GA `adopt_click` event with beacon transport on adoptions page clicks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb7b7619248331b4c4b2d9cca8af3a